### PR TITLE
feat(api): add initial FastAPI scaffold (routes, models, alembic, celery)

### DIFF
--- a/pfa-api/.env.example
+++ b/pfa-api/.env.example
@@ -1,0 +1,8 @@
+API_HOST=0.0.0.0
+API_PORT=8000
+DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/pfa
+REDIS_URL=redis://redis:6379/0
+PLAID_ENV=sandbox
+PLAID_CLIENT_ID=replace-me
+PLAID_SECRET=replace-me
+SENTRY_DSN=

--- a/pfa-api/.github/workflows/api-ci.yml
+++ b/pfa-api/.github/workflows/api-ci.yml
@@ -1,0 +1,13 @@
+name: API CI
+on:
+  push:
+  pull_request:
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.12' }
+      - run: pip install -r requirements.txt pytest
+      - run: pytest -q

--- a/pfa-api/CONTRIBUTING.md
+++ b/pfa-api/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing Guidelines
+
+We use **trunk-based development** with **Conventional Commits**.
+
+## Branching
+- Default branch: `main`
+- Work off short-lived branches from `main`, e.g. `feat/simulator-impact-copy`.
+- Rebase onto `main` before merging (no long-lived branches).
+
+## Commits — Conventional Commits
+Format: `<type>(scope)!: short summary`
+
+Types: `feat|fix|docs|refactor|perf|test|build|ci|chore`  
+Examples:
+- `feat(simulator): add impact suggestions`
+- `fix(budgets): correct ATS rounding`
+- `refactor(api): extract plaid client factory`
+- `chore(ci): add commitlint`
+
+## Pull Requests
+- 1–3 reviewers; small PRs (<300 lines) whenever possible.
+- Linked issue or checklist of acceptance criteria.
+- Title must follow Conventional Commits (CI enforces).
+
+## CI Gates
+- Lint & tests must pass.
+- Commit messages validated by **commitlint**.
+
+## Local hooks (optional)
+- Node present? You can enable local commit message checks:
+
+### For Node repos (pfa-app)
+```bash
+bash scripts/setup-husky.sh
+```
+
+### For Python repo (pfa-api)
+We enforce commit style in CI. If you want a local hook, run the Node variant above in this repo too.

--- a/pfa-api/Dockerfile
+++ b/pfa-api/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 8000

--- a/pfa-api/README.md
+++ b/pfa-api/README.md
@@ -1,0 +1,3 @@
+# PFA API
+
+FastAPI scaffold for Personal Financial Advisor app.

--- a/pfa-api/alembic.ini
+++ b/pfa-api/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = ${DATABASE_URL}

--- a/pfa-api/alembic/env.py
+++ b/pfa-api/alembic/env.py
@@ -1,0 +1,30 @@
+from logging.config import fileConfig
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+import os
+from app.db.session import Base
+from app import models  # noqa: F401
+
+config = context.config
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+def run_migrations_offline() -> None:
+    url = os.getenv("DATABASE_URL")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config({"sqlalchemy.url": os.getenv("DATABASE_URL")}, prefix="sqlalchemy.", poolclass=pool.NullPool)
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/pfa-api/app/api/routes/budgets.py
+++ b/pfa-api/app/api/routes/budgets.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+from app.services.budgeting import compute_available_to_spend
+
+router = APIRouter(prefix="/budgets", tags=["budgets"])
+
+@router.get("/current")
+async def get_current_budget():
+    lines = [
+        {"category":"Rent","planned":1300,"spent":1300},
+        {"category":"Groceries","planned":400,"spent":220},
+        {"category":"Dining","planned":250,"spent":190},
+        {"category":"Transport","planned":200,"spent":80},
+        {"category":"Savings","planned":500,"spent":500},
+    ]
+    ats = compute_available_to_spend(lines)
+    return {"lines": lines, "available_to_spend": ats}

--- a/pfa-api/app/api/routes/goals.py
+++ b/pfa-api/app/api/routes/goals.py
@@ -1,0 +1,11 @@
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/goals", tags=["goals"])
+
+@router.post("")
+async def create_goal(goal: dict):
+    return {"ok": True, "goal": goal}
+
+@router.get("")
+async def list_goals():
+    return {"goals": []}

--- a/pfa-api/app/api/routes/health.py
+++ b/pfa-api/app/api/routes/health.py
@@ -1,0 +1,8 @@
+from fastapi import APIRouter
+from app.schemas.common import Health
+
+router = APIRouter()
+
+@router.get("/health", response_model=Health)
+async def health():
+    return Health()

--- a/pfa-api/app/api/routes/plaid.py
+++ b/pfa-api/app/api/routes/plaid.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter
+from app.schemas.common import LinkToken, PublicToken
+from app.services import plaid as plaid_svc
+
+router = APIRouter(prefix="/plaid", tags=["plaid"])
+
+@router.post("/link_token", response_model=LinkToken)
+async def link_token():
+    token = plaid_svc.create_link_token("demo-user")
+    return LinkToken(**token)
+
+@router.post("/exchange")
+async def exchange(body: PublicToken):
+    data = plaid_svc.exchange_public_token(body.public_token)
+    return data
+
+@router.post("/webhook")
+async def webhook(payload: dict):
+    return {"ok": True}

--- a/pfa-api/app/api/routes/simulator.py
+++ b/pfa-api/app/api/routes/simulator.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter
+from app.schemas.common import SimulatorRequest, SimulatorResponse
+from app.services.simulator import simulate_purchase
+from app.services.budgeting import compute_available_to_spend
+
+router = APIRouter(prefix="/simulator", tags=["simulator"])
+
+@router.post("/check", response_model=SimulatorResponse)
+async def check(body: SimulatorRequest):
+    ats = compute_available_to_spend([
+        {"category":"Groceries","planned":400,"spent":220},
+        {"category":"Dining","planned":250,"spent":190},
+    ])
+    impact, suggestions = simulate_purchase(body.price, body.category_hint, ats)
+    return SimulatorResponse(impact=impact, suggestions=suggestions)

--- a/pfa-api/app/api/routes/transactions.py
+++ b/pfa-api/app/api/routes/transactions.py
@@ -1,0 +1,13 @@
+from fastapi import APIRouter
+from app.jobs.tasks import sync_transactions_task
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+@router.get("")
+async def list_transactions(since: str | None = None):
+    return {"transactions": []}
+
+@router.post("/sync")
+async def sync_now():
+    res = sync_transactions_task.delay(1)
+    return {"enqueued": True, "task_id": res.id}

--- a/pfa-api/app/core/config.py
+++ b/pfa-api/app/core/config.py
@@ -1,0 +1,15 @@
+import os
+from functools import lru_cache
+
+class Settings:
+    API_HOST: str = os.getenv("API_HOST", "0.0.0.0")
+    API_PORT: int = int(os.getenv("API_PORT", "8000"))
+    DATABASE_URL: str = os.getenv("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/pfa")
+    REDIS_URL: str = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    PLAID_ENV: str = os.getenv("PLAID_ENV", "sandbox")
+    PLAID_CLIENT_ID: str = os.getenv("PLAID_CLIENT_ID", "")
+    PLAID_SECRET: str = os.getenv("PLAID_SECRET", "")
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/pfa-api/app/db/session.py
+++ b/pfa-api/app/db/session.py
@@ -1,0 +1,14 @@
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase
+from app.core.config import get_settings
+
+settings = get_settings()
+engine = create_async_engine(settings.DATABASE_URL, future=True, echo=False)
+AsyncSessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+class Base(DeclarativeBase):
+    pass
+
+async def get_db():
+    async with AsyncSessionLocal() as session:
+        yield session

--- a/pfa-api/app/jobs/celery_app.py
+++ b/pfa-api/app/jobs/celery_app.py
@@ -1,0 +1,6 @@
+from celery import Celery
+from app.core.config import get_settings
+
+settings = get_settings()
+celery_app = Celery("pfa", broker=settings.REDIS_URL, backend=settings.REDIS_URL)
+celery_app.conf.task_routes = {"app.jobs.tasks.*": {"queue": "default"}}

--- a/pfa-api/app/jobs/tasks.py
+++ b/pfa-api/app/jobs/tasks.py
@@ -1,0 +1,5 @@
+from app.jobs.celery_app import celery_app
+
+@celery_app.task
+def sync_transactions_task(user_id: int) -> dict:
+    return {"status": "ok", "user_id": user_id, "synced": 42}

--- a/pfa-api/app/main.py
+++ b/pfa-api/app/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from app.api.routes.health import router as health_router
+from app.api.routes.plaid import router as plaid_router
+from app.api.routes.transactions import router as transactions_router
+from app.api.routes.budgets import router as budgets_router
+from app.api.routes.goals import router as goals_router
+from app.api.routes.simulator import router as simulator_router
+
+app = FastAPI(title="PFA API", version="0.1.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.include_router(health_router)
+app.include_router(plaid_router)
+app.include_router(transactions_router)
+app.include_router(budgets_router)
+app.include_router(goals_router)
+app.include_router(simulator_router)

--- a/pfa-api/app/models/__init__.py
+++ b/pfa-api/app/models/__init__.py
@@ -1,0 +1,5 @@
+from app.models.user import User  # noqa
+from app.models.account import Account  # noqa
+from app.models.transaction import Transaction  # noqa
+from app.models.budget import Budget, BudgetLine  # noqa
+from app.models.goal import Goal  # noqa

--- a/pfa-api/app/models/account.py
+++ b/pfa-api/app/models/account.py
@@ -1,0 +1,13 @@
+from sqlalchemy import ForeignKey, String
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.session import Base
+
+class Account(Base):
+    __tablename__ = "accounts"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    provider: Mapped[str] = mapped_column(String(50))
+    mask: Mapped[str] = mapped_column(String(8))
+    name: Mapped[str] = mapped_column(String(120))
+    item_id: Mapped[str] = mapped_column(String(128))
+    access_token_enc: Mapped[str] = mapped_column(String(512))

--- a/pfa-api/app/models/budget.py
+++ b/pfa-api/app/models/budget.py
@@ -1,0 +1,18 @@
+from sqlalchemy import ForeignKey, String, Numeric, Date
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.session import Base
+
+class Budget(Base):
+    __tablename__ = "budgets"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    period_start: Mapped[str] = mapped_column(Date)
+    period_end: Mapped[str] = mapped_column(Date)
+
+class BudgetLine(Base):
+    __tablename__ = "budget_lines"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    budget_id: Mapped[int] = mapped_column(ForeignKey("budgets.id", ondelete="CASCADE"), index=True)
+    category: Mapped[str] = mapped_column(String(64), index=True)
+    planned: Mapped[float] = mapped_column(Numeric(14,2))
+    spent: Mapped[float] = mapped_column(Numeric(14,2), default=0)

--- a/pfa-api/app/models/goal.py
+++ b/pfa-api/app/models/goal.py
@@ -1,0 +1,13 @@
+from sqlalchemy import ForeignKey, String, Numeric, Date
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.session import Base
+
+class Goal(Base):
+    __tablename__ = "goals"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), index=True)
+    name: Mapped[str] = mapped_column(String(120))
+    target_amount: Mapped[float] = mapped_column(Numeric(14,2))
+    target_date: Mapped[str] = mapped_column(Date)
+    start_balance: Mapped[float] = mapped_column(Numeric(14,2), default=0)
+    cadence: Mapped[str] = mapped_column(String(16), default="monthly")

--- a/pfa-api/app/models/transaction.py
+++ b/pfa-api/app/models/transaction.py
@@ -1,0 +1,13 @@
+from sqlalchemy import ForeignKey, String, Numeric, Date
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.session import Base
+
+class Transaction(Base):
+    __tablename__ = "transactions"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    account_id: Mapped[int] = mapped_column(ForeignKey("accounts.id", ondelete="CASCADE"), index=True)
+    date: Mapped[str] = mapped_column(Date, index=True)
+    amount: Mapped[float] = mapped_column(Numeric(14,2))
+    merchant: Mapped[str] = mapped_column(String(256))
+    category: Mapped[str] = mapped_column(String(64), index=True)
+    raw_json: Mapped[str] = mapped_column(String)

--- a/pfa-api/app/models/user.py
+++ b/pfa-api/app/models/user.py
@@ -1,0 +1,8 @@
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
+from app.db.session import Base
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True, index=True)
+    email: Mapped[str] = mapped_column(String(320), unique=True, index=True)

--- a/pfa-api/app/schemas/common.py
+++ b/pfa-api/app/schemas/common.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+
+class Health(BaseModel):
+    status: str = "ok"
+
+class LinkToken(BaseModel):
+    link_token: str
+
+class PublicToken(BaseModel):
+    public_token: str
+
+class SimulatorRequest(BaseModel):
+    price: float
+    merchant: str
+    category_hint: str | None = None
+
+class SimulatorResponse(BaseModel):
+    impact: str
+    suggestions: list[str] = []

--- a/pfa-api/app/services/budgeting.py
+++ b/pfa-api/app/services/budgeting.py
@@ -1,0 +1,6 @@
+def compute_available_to_spend(budget_lines: list[dict]) -> float:
+    remaining = 0.0
+    for bl in budget_lines:
+        if bl.get("category") not in {"Rent","Debt","Savings"}:
+            remaining += float(bl.get("planned", 0)) - float(bl.get("spent", 0))
+    return round(remaining, 2)

--- a/pfa-api/app/services/plaid.py
+++ b/pfa-api/app/services/plaid.py
@@ -1,0 +1,5 @@
+def create_link_token(user_id: str) -> dict:
+    return {"link_token": "sandbox-link-pretend-token"}
+
+def exchange_public_token(public_token: str) -> dict:
+    return {"access_token": "access-sandbox-xyz", "item_id": "item-sandbox-abc"}

--- a/pfa-api/app/services/simulator.py
+++ b/pfa-api/app/services/simulator.py
@@ -1,0 +1,6 @@
+def simulate_purchase(price: float, category: str | None, ats: float) -> tuple[str, list[str]]:
+    after = ats - price
+    if after >= 0:
+        return (f"OK — still on plan. ATS after purchase: ${after:.2f}", [])
+    suggestions = [f"Reduce {category or 'another category'} by ${abs(after):.2f}", "Delay purchase or split over two periods"]
+    return (f"Off plan by ${abs(after):.2f}", suggestions)

--- a/pfa-api/docker-compose.yml
+++ b/pfa-api/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  api:
+    build: .
+    env_file: .env
+    ports: ["8000:8000"]
+    depends_on: [db, redis]
+    command: >
+      bash -lc "alembic upgrade head && uvicorn app.main:app --host ${API_HOST:-0.0.0.0} --port ${API_PORT:-8000}"
+  worker:
+    build: .
+    env_file: .env
+    depends_on: [db, redis]
+    command: celery -A app.jobs.celery_app.celery_app worker --loglevel=INFO
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: pfa
+    ports: ["5432:5432"]
+    volumes: [pfa_pg:/var/lib/postgresql/data]
+  redis:
+    image: redis:7-alpine
+    ports: ["6379:6379"]
+volumes:
+  pfa_pg:

--- a/pfa-api/docs/github-branch-protection.md
+++ b/pfa-api/docs/github-branch-protection.md
@@ -1,0 +1,12 @@
+# GitHub Branch Protection (configure in Settings → Branches)
+
+Recommended rules for `main`:
+- Require a pull request before merging
+- Require approvals: 1–2
+- Dismiss stale approvals when new commits are pushed
+- Require status checks to pass before merging:
+  - API CI (tests)
+  - App CI (typecheck)
+  - Commitlint
+- Require linear history (optional)
+- Restrict who can push to matching branches (maintainers only)

--- a/pfa-api/pfa-api-1.code-workspace
+++ b/pfa-api/pfa-api-1.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": "../../../pfa-api-1"
+		},
+		{
+			"path": "."
+		}
+	],
+	"settings": {}
+}

--- a/pfa-api/requirements.txt
+++ b/pfa-api/requirements.txt
@@ -1,0 +1,15 @@
+fastapi==0.115.5
+uvicorn[standard]==0.30.6
+pydantic==2.9.2
+SQLAlchemy==2.0.36
+alembic==1.13.2
+asyncpg==0.30.0
+redis==5.0.8
+celery==5.4.0
+httpx==0.27.2
+python-dotenv==1.0.1
+python-jose==3.3.0
+passlib[bcrypt]==1.7.4
+plaid-python==15.0.0
+boto3==1.34.158
+sentry-sdk==2.13.0

--- a/pfa-api/tests/test_health.py
+++ b/pfa-api/tests/test_health.py
@@ -1,0 +1,8 @@
+from fastapi.testclient import TestClient
+from app.main import app
+client = TestClient(app)
+
+def test_health():
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"


### PR DESCRIPTION
### 🚀 Overview  
This PR introduces the **initial backend scaffold** for the Personal Financial Advisor (PFA) API. It lays the groundwork for future features like Plaid integration, transaction syncing, budgeting, and goals.  

---

### 🛠 What’s Included  
- **Framework & Infra**  
  - FastAPI application with CORS enabled  
  - Dockerfile + docker-compose for API, worker, Postgres, Redis  
  - `.env.example` for environment configuration  
  - Alembic migrations configured  

- **Core App**  
  - `app/main.py` with routes:  
    - `/health`  
    - `/budgets/current`  
    - `/simulator/check`  
    - `/goals`  
    - `/transactions`  
    - `/plaid` (stubbed)  
  - Models for `User`, `Account`, `Transaction`, `Budget`, `Goal`  
  - SQLAlchemy async session + database config  
  - Celery worker setup with Redis broker/backend  

- **Services**  
  - Budgeting: available-to-spend calculation  
  - Simulator: purchase impact simulator  
  - Plaid: stub functions for link token + public token exchange  

- **Testing & CI**  
  - Basic health check test (`pytest`)  
  - GitHub Actions workflow for CI  

---

### ✅ Next Steps  
- Replace Plaid stubs with sandbox calls  
- Implement `/transactions/sync` with Plaid’s API  
- Add auth layer and per-user data scoping  
- Expand tests for routes and services  
